### PR TITLE
Update testcontainers version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <smackx.version>3.1.0</smackx.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <jacoco.version>0.8.5</jacoco.version>
         <mockito.version>3.3.3</mockito.version>
     </properties>


### PR DESCRIPTION
With the current version of Docker i.e.

    % dockerd -v
    Docker version 27.3.1, build 41ca978

end to end tests fail with the message below:

    [ERROR] com.belano.auctionsniper.xmpp.XMPPAuctionHouseTest  Time elapsed: 0.019 s  <<< ERROR!
    org.testcontainers.containers.ContainerLaunchException: Container startup failed
    Caused by: org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=goos/openfire:latest, imagePullPolicy=DefaultPullPolicy())
    Caused by: java.lang.IllegalStateException: Previous attempts to find a Docker environment failed. Will not retry. Please see logs and check configuration

This is fixed by updating testcontainers to a newer version.

See also

https://github.com/testcontainers/testcontainers-java/issues/3574#issuecomment-989938970